### PR TITLE
Potential fix for code scanning alert no. 33: Potentially overflowing call to snprintf

### DIFF
--- a/diameter.c
+++ b/diameter.c
@@ -847,8 +847,19 @@ int diameter_parser(const unsigned char *packet, int size_payload, char *json_bu
             offset += (rat_type_len + padd);  // update offset
 
             // put buffer in JSON buffer
-            js_ret += snprintf((json_buffer + js_ret), buffer_len - js_ret,
-                               "\"rat-type\":%u, ", rat_type);
+            {
+                size_t rem = (js_ret < buffer_len) ? (buffer_len - js_ret) : 0;
+                int n = snprintf((json_buffer + js_ret), rem,
+                                 "\"rat-type\":%u, ", rat_type);
+                if (n < 0) {
+                    return -1;
+                }
+                if ((size_t)n >= rem) {
+                    js_ret = buffer_len;
+                    return js_ret;
+                }
+                js_ret += (size_t)n;
+            }
             break;
         }
 
@@ -871,8 +882,18 @@ int diameter_parser(const unsigned char *packet, int size_payload, char *json_bu
         } // switch
     }
 
-    js_ret += snprintf((json_buffer + js_ret - 2), 3, "%s", "}}");
-    js_ret -= 2;
+    {
+        size_t base = (js_ret >= 2) ? (js_ret - 2) : js_ret;
+        size_t rem = (base < buffer_len) ? (buffer_len - base) : 0;
+        int n = snprintf((json_buffer + base), rem, "%s", "}}");
+        if (n < 0) {
+            return -1;
+        }
+        if ((size_t)n >= rem) {
+            return buffer_len;
+        }
+        js_ret = base + (size_t)n;
+    }
 
     return js_ret; // OK
 }


### PR DESCRIPTION
Potential fix for [https://github.com/kYroL01/Decoder/security/code-scanning/33](https://github.com/kYroL01/Decoder/security/code-scanning/33)

The correct fix is to stop accumulating `snprintf`’s raw return value directly into `js_ret` unless it is validated against remaining space.

Best minimal fix in the shown region:
1. Replace the flagged call at lines 850–851 with:
   - compute remaining space safely (`buffer_len > js_ret ? buffer_len - js_ret : 0`);
   - call `snprintf`;
   - if return `< 0`, fail safely (`return -1`);
   - if return `>= remaining`, clamp `js_ret` to `buffer_len` and return (or otherwise stop writing);
   - else add the returned count to `js_ret`.
2. Apply same safe pattern to the final closing write at line 874 to avoid the same class of bug there (it also uses accumulated `js_ret` in buffer arithmetic).

All changes are confined to `diameter.c` in the shown function body; no new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
