### PR TITLE
Potential fix for code scanning alert no. 32: Potentially overflowing call to snprintf

### DIFF
--- a/diameter.c
+++ b/diameter.c
@@ -827,8 +827,19 @@ int diameter_parser(const unsigned char *packet, int size_payload, char *json_bu
             offset += (ip_can_type_len + padd);  // update offset
 
             // put buffer in JSON buffer
-            js_ret += snprintf((json_buffer + js_ret), buffer_len - js_ret,
-                               "\"ip-can-type\":%u, ", ip_can_type);
+            {
+                size_t rem = (js_ret < buffer_len) ? (buffer_len - js_ret) : 0;
+                int n = snprintf((json_buffer + js_ret), rem,
+                                 "\"ip-can-type\":%u, ", ip_can_type);
+                if (n < 0) {
+                    return -1;
+                }
+                if ((size_t)n >= rem) {
+                    js_ret = buffer_len;
+                    return js_ret;
+                }
+                js_ret += (size_t)n;
+            }
             break;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/kYroL01/Decoder/security/code-scanning/32](https://github.com/kYroL01/Decoder/security/code-scanning/32)

The fix is to stop adding `snprintf`’s return value directly to `js_ret`. Instead, compute remaining space safely, call `snprintf`, check errors, detect truncation (`n >= rem`), and only then increment `js_ret` by `n`.

Best minimal fix (no functionality change) is to rewrite only the JSON append in `case IP_CAN_TYPE` (around lines 829–832) to match the safe style already used in `case RAT_TYPE`:
- Compute `rem = (js_ret < buffer_len) ? (buffer_len - js_ret) : 0`.
- `n = snprintf(...)`.
- If `n < 0`, return `-1`.
- If `(size_t)n >= rem`, set `js_ret = buffer_len` and return `js_ret` (same behavior style as nearby block).
- Else `js_ret += (size_t)n`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
